### PR TITLE
Set the `main` key in `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This project contains the Violet Conversation Engine that can be used as the bas
 Every voice script should start will typically start with declaring `violet` for use
 throughout:
 ```javascript
-var violet = require('violet/lib/violet.js').script();
+var violet = require('violet').script();
 ```
 
 See `examples/tutorial.js` for documentation on how to build a skill.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Framework for building sophisticated voice apps",
   "license": "BSD-3-Clause",
   "version": "0.7.3",
-  "main": "server.js",
+  "main": "lib/violet.js",
   "keywords": [
     "voice",
     "conversation",


### PR DESCRIPTION
Right now, the value for it is `server.j`, which does not exist.  This prevents
people from importing the package directly:

```
  const violet = require('violet');
```

By setting the `main` key to `lib/violet.js`, node will load that file when
the package is loaded directly.